### PR TITLE
Grant "Release" Action permission to write releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: write
+
 jobs:
   release:
     name: Create a PR for release workflow

--- a/package-lock.json
+++ b/package-lock.json
@@ -19243,7 +19243,7 @@
     },
     "packages/convex-vue": {
       "name": "@convex-vue/core",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "@auth0/auth0-vue": "^2.3.3",
         "@types/node": "^20.10.6",


### PR DESCRIPTION
The "Release" Action needs permission to write releases; it is currently failing at that step with the following:

```
/usr/bin/git push origin --tags
remote: Permission to loicpennequin/convex-vue.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/loicpennequin/convex-vue/': The requested URL returned error: 403
```

* Broken build: https://github.com/loicpennequin/convex-vue/actions/runs/7941447337/job/21683809122
* See permission docs on granting permissions to Actions: https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs