### PR TITLE
Add homepage, keywords, and correct repo for NPM

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19246,6 +19246,7 @@
     "packages/convex-vue": {
       "name": "@convex-vue/core",
       "version": "0.0.2",
+      "license": "MIT",
       "dependencies": {
         "@auth0/auth0-vue": "^2.3.3",
         "@vueuse/core": "^10.7.1",

--- a/packages/convex-vue/package.json
+++ b/packages/convex-vue/package.json
@@ -2,10 +2,16 @@
   "name": "@convex-vue/core",
   "version": "0.0.2",
   "description": "Vue integration for Convex",
+  "keywords": [
+    "convex",
+    "vue"
+  ],
+  "homepage": "https://github.com/loicpennequin/convex-vue",
+  "license": "MIT",
   "type": "module",
   "repository": {
     "type": "git",
-    "url": "https://github.com/loicpennequin/create-v3-app.git",
+    "url": "https://github.com/loicpennequin/convex-vue.git",
     "directory": "packages/convex-vue"
   },
   "files": [


### PR DESCRIPTION
Link back to the correct GitHub repo from package.json so the NPM page can get some navigation.