### PR TITLE
Remove unused deps, merge `peer` where necessary

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13488,7 +13488,8 @@
     "node_modules/open-props": {
       "version": "1.6.17",
       "resolved": "https://registry.npmjs.org/open-props/-/open-props-1.6.17.tgz",
-      "integrity": "sha512-6mp/gpLQz/ZwrGLz+i7tSJ3eWNLE1KxLXHO+b6xxRyZ1Alp4TgTcvHiQ89rC2IkvsU3/IRhpIJuxl7rRCwUzLA=="
+      "integrity": "sha512-6mp/gpLQz/ZwrGLz+i7tSJ3eWNLE1KxLXHO+b6xxRyZ1Alp4TgTcvHiQ89rC2IkvsU3/IRhpIJuxl7rRCwUzLA==",
+      "dev": true
     },
     "node_modules/open/node_modules/is-docker": {
       "version": "2.2.1",
@@ -14456,6 +14457,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.1.tgz",
       "integrity": "sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw==",
+      "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -19243,43 +19245,24 @@
     },
     "packages/convex-vue": {
       "name": "@convex-vue/core",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "@auth0/auth0-vue": "^2.3.3",
-        "@types/node": "^20.10.6",
         "@vueuse/core": "^10.7.1",
         "convex": "^1.7.1",
-        "open-props": "^1.6.17",
-        "prettier": "^3.1.1",
-        "type-fest": "^4.9.0",
         "vue": "^3.3.11",
         "vue-router": "^4.2.5"
       },
       "devDependencies": {
-        "@types/node": "^20.10.6",
         "@vitejs/plugin-vue": "^4.5.2",
         "npm-run-all": "^4.1.5",
+        "open-props": "^1.6.17",
+        "prettier": "^3.1.1",
         "typescript": "^5.2.2",
         "unplugin-vue-router": "^0.7.0",
         "vite": "^5.0.8",
         "vite-plugin-dts": "^3.7.2",
         "vue-tsc": "^1.8.25"
-      },
-      "peerDependencies": {
-        "@vueuse/core": "^10.7.1",
-        "convex": "^1.7.1",
-        "vue-router": "^4.2.5"
-      }
-    },
-    "packages/convex-vue/node_modules/type-fest": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.9.0.tgz",
-      "integrity": "sha512-KS/6lh/ynPGiHD/LnAobrEFq3Ad4pBzOlJ1wAnJx9N4EYoqFhMfLIBjUT2UEx4wg5ZE+cC1ob6DCSpppVo+rtg==",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "packages/nuxt": {

--- a/packages/convex-vue/package.json
+++ b/packages/convex-vue/package.json
@@ -27,26 +27,18 @@
     "build": "vue-tsc && vite build",
     "preview": "vite preview"
   },
-  "peerDependencies": {
-    "@vueuse/core": "^10.7.1",
-    "convex": "^1.7.1",
-    "vue-router": "^4.2.5"
-  },
   "dependencies": {
     "@auth0/auth0-vue": "^2.3.3",
-    "@types/node": "^20.10.6",
     "@vueuse/core": "^10.7.1",
     "convex": "^1.7.1",
-    "open-props": "^1.6.17",
-    "prettier": "^3.1.1",
-    "type-fest": "^4.9.0",
     "vue": "^3.3.11",
     "vue-router": "^4.2.5"
   },
   "devDependencies": {
-    "@types/node": "^20.10.6",
     "@vitejs/plugin-vue": "^4.5.2",
     "npm-run-all": "^4.1.5",
+    "open-props": "^1.6.17",
+    "prettier": "^3.1.1",
     "typescript": "^5.2.2",
     "unplugin-vue-router": "^0.7.0",
     "vite": "^5.0.8",


### PR DESCRIPTION
Each of the deps listed in "peerDependencies" is directly imported/used by this package so they should be listed as regular "dependencies."

* Remove "type-fest", it is not referenced
* Remove "@types/node", it is not referenced
* Move both "open-props" and "prettier" to dev deps since they are only needed during the build